### PR TITLE
refactor: centralize number formatting

### DIFF
--- a/altfin-nextjs/src/components/Assumptions.tsx
+++ b/altfin-nextjs/src/components/Assumptions.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { formatNumber } from '../utils/format';
+
 interface Assumptions {
   [key: string]: number;
 }
@@ -180,7 +182,11 @@ export default function Assumptions({ assumptions, onAssumptionChange, onScenari
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
           <div className="text-center p-4 bg-green-50 rounded-lg">
             <div className="text-2xl font-bold text-green-600">
-              {assumptions.startingTransactions || 0}
+              {formatNumber(assumptions.startingTransactions || 0, {
+                style: 'decimal',
+                minimumFractionDigits: 0,
+                maximumFractionDigits: 0,
+              })}
             </div>
             <div className="text-sm text-gray-600">Starting Transactions</div>
           </div>
@@ -192,7 +198,7 @@ export default function Assumptions({ assumptions, onAssumptionChange, onScenari
           </div>
           <div className="text-center p-4 bg-purple-50 rounded-lg">
             <div className="text-2xl font-bold text-purple-600">
-              R{(assumptions.averageOrderValue || 0).toLocaleString()}
+              {formatNumber(assumptions.averageOrderValue || 0)}
             </div>
             <div className="text-sm text-gray-600">Average Order Value</div>
           </div>

--- a/altfin-nextjs/src/components/Dashboard.tsx
+++ b/altfin-nextjs/src/components/Dashboard.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo } from 'react';
+import { formatNumber } from '../utils/format';
 
 interface Assumptions {
   [key: string]: number;
@@ -12,16 +13,6 @@ interface DashboardProps {
 
 export default function Dashboard({ assumptions }: DashboardProps) {
   // Helper functions defined at the top
-  function formatCurrency(amount: number): string {
-    if (amount === 0) return '0';
-    
-    // Use a consistent number formatting approach that works the same on server and client
-    const absAmount = Math.abs(amount);
-    const formatted = absAmount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-    
-    if (amount < 0) return `-${formatted}`;
-    return formatted;
-  }
 
   function calculateMonthlyRevenue(month: number, assumptions: Assumptions): number {
     // ONLY the transaction volume grows at 3% per quarter
@@ -272,16 +263,16 @@ export default function Dashboard({ assumptions }: DashboardProps) {
           <div className="space-y-2">
             <div className="flex justify-between">
               <span className="text-gray-600">Revenue:</span>
-              <span className="font-semibold text-green-600">{formatCurrency(calculations.phase1.revenue)}</span>
+              <span className="font-semibold text-green-600">{formatNumber(calculations.phase1.revenue)}</span>
             </div>
             <div className="flex justify-between">
               <span className="text-gray-600">Costs:</span>
-              <span className="font-semibold text-red-600">{formatCurrency(calculations.phase1.costs)}</span>
+              <span className="font-semibold text-red-600">{formatNumber(calculations.phase1.costs)}</span>
             </div>
             <div className="flex justify-between pt-2 border-t">
               <span className="text-gray-800 font-semibold">Profit:</span>
               <span className={`font-bold text-lg ${calculations.phase1.profit >= 0 ? 'text-green-600' : 'text-red-600'}`}>
-                {formatCurrency(calculations.phase1.profit)}
+                {formatNumber(calculations.phase1.profit)}
               </span>
             </div>
           </div>
@@ -293,16 +284,16 @@ export default function Dashboard({ assumptions }: DashboardProps) {
           <div className="space-y-2">
             <div className="flex justify-between">
               <span className="text-gray-600">Revenue:</span>
-              <span className="font-semibold text-green-600">{formatCurrency(calculations.phase2.revenue)}</span>
+              <span className="font-semibold text-green-600">{formatNumber(calculations.phase2.revenue)}</span>
             </div>
             <div className="flex justify-between">
               <span className="text-gray-600">Costs:</span>
-              <span className="font-semibold text-red-600">{formatCurrency(calculations.phase2.costs)}</span>
+              <span className="font-semibold text-red-600">{formatNumber(calculations.phase2.costs)}</span>
             </div>
             <div className="flex justify-between pt-2 border-t">
               <span className="text-gray-800 font-semibold">Profit:</span>
               <span className={`font-bold text-lg ${calculations.phase2.profit >= 0 ? 'text-green-600' : 'text-red-600'}`}>
-                {formatCurrency(calculations.phase2.profit)}
+                {formatNumber(calculations.phase2.profit)}
               </span>
             </div>
           </div>
@@ -314,13 +305,13 @@ export default function Dashboard({ assumptions }: DashboardProps) {
           <div className="space-y-2">
             <div className="flex justify-between">
               <span className="text-gray-600">Revenue:</span>
-              <span className="font-semibold text-green-600">{formatCurrency(calculations.phase3.revenue)}</span>
+              <span className="font-semibold text-green-600">{formatNumber(calculations.phase3.revenue)}</span>
             </div>
             <div className="flex justify-between">
               <span className="text-gray-600">Costs:</span>
               <span className="font-semibold text-red-600">{(() => {
                 console.log('Phase 3 costs before formatting:', calculations.phase3.costs);
-                const formatted = formatCurrency(calculations.phase3.costs);
+                const formatted = formatNumber(calculations.phase3.costs);
                 console.log('Phase 3 costs after formatting:', formatted);
                 return formatted;
               })()}</span>
@@ -328,7 +319,7 @@ export default function Dashboard({ assumptions }: DashboardProps) {
             <div className="flex justify-between pt-2 border-t">
               <span className="text-gray-800 font-semibold">Profit:</span>
               <span className={`font-bold text-lg ${calculations.phase3.profit >= 0 ? 'text-green-600' : 'text-red-600'}`}>
-                {formatCurrency(calculations.phase3.profit)}
+                {formatNumber(calculations.phase3.profit)}
               </span>
             </div>
           </div>
@@ -340,16 +331,16 @@ export default function Dashboard({ assumptions }: DashboardProps) {
           <div className="space-y-2">
             <div className="flex justify-between">
               <span className="text-gray-600">Revenue:</span>
-              <span className="font-semibold text-green-600">{formatCurrency(calculations.total.revenue)}</span>
+              <span className="font-semibold text-green-600">{formatNumber(calculations.total.revenue)}</span>
             </div>
             <div className="flex justify-between">
               <span className="text-gray-600">Costs:</span>
-              <span className="font-semibold text-red-600">{formatCurrency(calculations.total.costs)}</span>
+              <span className="font-semibold text-red-600">{formatNumber(calculations.total.costs)}</span>
             </div>
             <div className="flex justify-between pt-2 border-t">
               <span className="text-gray-800 font-semibold">Profit:</span>
               <span className={`font-bold text-lg ${calculations.total.profit >= 0 ? 'text-green-600' : 'text-red-600'}`}>
-                {formatCurrency(calculations.total.profit)}
+                {formatNumber(calculations.total.profit)}
               </span>
             </div>
           </div>
@@ -375,36 +366,36 @@ export default function Dashboard({ assumptions }: DashboardProps) {
             <tbody className="bg-white divide-y divide-gray-200">
               <tr className="bg-blue-50">
                 <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-blue-900">Phase 1: Setup & Launch (M1-3)</td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-green-600 font-semibold">{formatCurrency(calculations.phase1.revenue)}</td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-red-600 font-semibold">{formatCurrency(calculations.phase1.costs)}</td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-right font-semibold">{formatCurrency(calculations.phase1.profit)}</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-green-600 font-semibold">{formatNumber(calculations.phase1.revenue)}</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-red-600 font-semibold">{formatNumber(calculations.phase1.costs)}</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-right font-semibold">{formatNumber(calculations.phase1.profit)}</td>
                 <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-gray-600">
                   {calculations.phase1.revenue > 0 ? ((calculations.phase1.profit / calculations.phase1.revenue) * 100).toFixed(1) : 0}%
                 </td>
               </tr>
               <tr className="bg-green-50">
                 <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-green-900">Phase 2: Market Entry (M4-6)</td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-green-600 font-semibold">{formatCurrency(calculations.phase2.revenue)}</td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-red-600 font-semibold">{formatCurrency(calculations.phase2.costs)}</td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-right font-semibold">{formatCurrency(calculations.phase2.profit)}</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-green-600 font-semibold">{formatNumber(calculations.phase2.revenue)}</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-red-600 font-semibold">{formatNumber(calculations.phase2.costs)}</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-right font-semibold">{formatNumber(calculations.phase2.profit)}</td>
                 <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-gray-600">
                   {calculations.phase2.revenue > 0 ? ((calculations.phase2.profit / calculations.phase2.revenue) * 100).toFixed(1) : 0}%
                 </td>
               </tr>
               <tr className="bg-orange-50">
                 <td className="px-6 py-4 whitespace-nowrap text-sm font-medium text-orange-900">Phase 3: Scale (M7-24)</td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-green-600 font-semibold">{formatCurrency(calculations.phase3.revenue)}</td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-red-600 font-semibold">{formatCurrency(calculations.phase3.costs)}</td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-right font-semibold">{formatCurrency(calculations.phase3.profit)}</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-green-600 font-semibold">{formatNumber(calculations.phase3.revenue)}</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-red-600 font-semibold">{formatNumber(calculations.phase3.costs)}</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-right font-semibold">{formatNumber(calculations.phase3.profit)}</td>
                 <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-gray-600">
                   {calculations.phase3.revenue > 0 ? ((calculations.phase3.profit / calculations.phase3.revenue) * 100).toFixed(1) : 0}%
                 </td>
               </tr>
               <tr className="bg-gray-900 text-white">
                 <td className="px-6 py-4 whitespace-nowrap text-sm font-bold">TOTAL 24-MONTH PROJECTION</td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-green-400 font-bold">{formatCurrency(calculations.total.revenue)}</td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-red-400 font-bold">{formatCurrency(calculations.total.costs)}</td>
-                <td className="px-6 py-4 whitespace-nowrap text-sm text-right font-bold">{formatCurrency(calculations.total.profit)}</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-green-400 font-bold">{formatNumber(calculations.total.revenue)}</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-red-400 font-bold">{formatNumber(calculations.total.costs)}</td>
+                <td className="px-6 py-4 whitespace-nowrap text-sm text-right font-bold">{formatNumber(calculations.total.profit)}</td>
                 <td className="px-6 py-4 whitespace-nowrap text-sm text-right text-gray-300">
                   {calculations.total.revenue > 0 ? ((calculations.total.profit / calculations.total.revenue) * 100).toFixed(1) : 0}%
                 </td>

--- a/altfin-nextjs/src/components/FinancialModel.tsx
+++ b/altfin-nextjs/src/components/FinancialModel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo } from 'react';
+import { formatNumber } from '../utils/format';
 
 interface Assumptions {
   [key: string]: number;
@@ -12,17 +13,6 @@ interface FinancialModelProps {
 
 export default function FinancialModel({ assumptions }: FinancialModelProps) {
   // Helper functions defined at the top
-  function formatCurrency(amount: number): string {
-    if (amount === 0) return '0';
-    
-    // Use a consistent number formatting approach that works the same on server and client
-    const absAmount = Math.abs(amount);
-    const formatted = absAmount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-    
-    if (amount < 0) return `-${formatted}`;
-    return formatted;
-  }
-
   function calculateSum(values: (string | number)[]): number {
     return values.reduce((sum: number, val: string | number) => {
       if (typeof val === 'string') {
@@ -75,13 +65,16 @@ export default function FinancialModel({ assumptions }: FinancialModelProps) {
                     {row.label}
                   </td>
                   {row.values.map((value, colIndex) => (
-                    <td key={colIndex} className={`px-6 py-4 whitespace-nowrap text-sm text-center min-w-[100px] ${
-                      row.className === 'bg-blue-600 text-white' ? 'text-white' : 
-                      (typeof value === 'number' && value < 0) ? 'text-red-600' : 
-                      row.label.includes('Revenue') || row.label.includes('Total Revenue') ? 'text-green-600' : 
-                      'text-gray-900'
-                    }`}>
-                      {value}
+                    <td
+                      key={colIndex}
+                      className={`px-6 py-4 whitespace-nowrap text-sm text-center min-w-[100px] ${
+                        row.className === 'bg-blue-600 text-white' ? 'text-white' :
+                        (typeof value === 'number' && value < 0) ? 'text-red-600' :
+                        row.label.includes('Revenue') || row.label.includes('Total Revenue') ? 'text-green-600' :
+                        'text-gray-900'
+                      }`}
+                    >
+                      {typeof value === 'number' ? formatNumber(value) : value}
                     </td>
                   ))}
                 </tr>
@@ -99,13 +92,13 @@ export default function FinancialModel({ assumptions }: FinancialModelProps) {
             <div className="flex justify-between">
               <span className="text-gray-600">Total Revenue:</span>
               <span className="font-semibold text-green-600">
-                R{formatCurrency(calculateSum(financialModel.find(row => row.label === 'Total Revenue')?.values || []))}
+                {formatNumber(calculateSum(financialModel.find(row => row.label === 'Total Revenue')?.values || []))}
               </span>
             </div>
             <div className="flex justify-between">
               <span className="text-gray-600">Average Monthly:</span>
               <span className="font-semibold text-green-600">
-                R{formatCurrency(calculateSum(financialModel.find(row => row.label === 'Total Revenue')?.values || []) / 24)}
+                {formatNumber(calculateSum(financialModel.find(row => row.label === 'Total Revenue')?.values || []) / 24)}
               </span>
             </div>
           </div>
@@ -117,13 +110,13 @@ export default function FinancialModel({ assumptions }: FinancialModelProps) {
             <div className="flex justify-between">
               <span className="text-gray-600">Total Costs:</span>
               <span className="font-semibold text-red-600">
-                R{formatCurrency(calculateSum(financialModel.find(row => row.label === 'Total Costs')?.values || []))}
+                {formatNumber(calculateSum(financialModel.find(row => row.label === 'Total Costs')?.values || []))}
               </span>
             </div>
             <div className="flex justify-between">
               <span className="text-gray-600">Average Monthly:</span>
               <span className="font-semibold text-red-600">
-                R{formatCurrency(calculateSum(financialModel.find(row => row.label === 'Total Costs')?.values || []) / 24)}
+                {formatNumber(calculateSum(financialModel.find(row => row.label === 'Total Costs')?.values || []) / 24)}
               </span>
             </div>
           </div>
@@ -135,13 +128,13 @@ export default function FinancialModel({ assumptions }: FinancialModelProps) {
             <div className="flex justify-between">
               <span className="text-gray-600">Total Profit:</span>
               <span className="font-semibold text-blue-600">
-                R{formatCurrency(calculateSum(financialModel.find(row => row.label === 'Net Profit')?.values || []))}
+                {formatNumber(calculateSum(financialModel.find(row => row.label === 'Net Profit')?.values || []))}
               </span>
             </div>
             <div className="flex justify-between">
               <span className="text-gray-600">Average Monthly:</span>
               <span className="font-semibold text-blue-600">
-                R{formatCurrency(calculateSum(financialModel.find(row => row.label === 'Net Profit')?.values || []) / 24)}
+                {formatNumber(calculateSum(financialModel.find(row => row.label === 'Net Profit')?.values || []) / 24)}
               </span>
             </div>
           </div>

--- a/altfin-nextjs/src/utils/format.ts
+++ b/altfin-nextjs/src/utils/format.ts
@@ -1,0 +1,10 @@
+export function formatNumber(value: number, options: Intl.NumberFormatOptions = {}): string {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'ZAR',
+    currencyDisplay: 'narrowSymbol',
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+    ...options,
+  }).format(value);
+}


### PR DESCRIPTION
## Summary
- add shared `formatNumber` helper using `Intl.NumberFormat`
- switch assumptions summary to shared formatter
- replace custom currency formatting in dashboard and financial model

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a60fc9f52c832288563bee1185e4c6